### PR TITLE
Replace Magento\Support\Model\Report\Group\Modules\Modules class

### DIFF
--- a/Plugin/GetFrontendUrl.php
+++ b/Plugin/GetFrontendUrl.php
@@ -7,20 +7,20 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Quote\Model\QuoteIdMaskFactory;
 use Magento\Sales\Model\Order;
 use Magento\Store\Model\StoreManagerInterface;
-use Magento\Support\Model\Report\Group\Modules\Modules;
+use Magento\Framework\Module\Manager;
 use Paytrail\PaymentService\Controller\Receipt\Index;
 
 class GetFrontendUrl
 {
     /**
      * @param QuoteIdMaskFactory $idMaskFactory
-     * @param Modules $modules
+     * @param Manager $moduleManager
      * @param ScopeConfigInterface $config
      * @param StoreManagerInterface $storeManager
      */
     public function __construct(
         private readonly QuoteIdMaskFactory    $idMaskFactory,
-        private readonly Modules               $modules,
+        private readonly Manager               $moduleManager,
         private readonly ScopeConfigInterface  $config,
         private readonly StoreManagerInterface $storeManager
     ) {
@@ -38,7 +38,7 @@ class GetFrontendUrl
      */
     public function afterGetSuccessUrl(Index $subject, string $result, Order $order): string
     {
-        if ($this->modules->isModuleEnabled('Magento_UpwardConnector')) {
+        if ($this->moduleManager->isEnabled('Magento_UpwardConnector')) {
             $frontendBaseUrl = $this->storeManager->getStore($order->getStoreId())->getBaseUrl(
                 \Magento\Framework\UrlInterface::URL_TYPE_WEB,
                 true
@@ -67,7 +67,7 @@ class GetFrontendUrl
      */
     public function afterGetCartUrl(Index $subject, string $result, Order $order): string
     {
-        if ($this->modules->isModuleEnabled('Magento_UpwardConnector')) {
+        if ($this->moduleManager->isEnabled('Magento_UpwardConnector')) {
             $frontendBaseUrl = $this->storeManager->getStore($order->getStoreId())->getBaseUrl(
                 \Magento\Framework\UrlInterface::URL_TYPE_WEB,
                 true


### PR DESCRIPTION
The class `Magento\Support\Model\Report\Group\Modules\Modules` doesn't exist in Magento Open Source -version. So this adds support for it. 

Usage of `Magento\Support\Model\Report\Group\Modules\Modules` throws an error during `bin/magento setup:di:compile` due to the class not existing so replacing it with `Magento\Framework\Module\Manager`.

Change the code to work with the new class.

The whole error:
```
In ClassReader.php line 57:
                                                                                                                                        
  Impossible to process constructor argument Parameter #1 [ <required> 
  Magento\Support\Model\Report\Group\Modules\Modules $modules ]
  of Paytrail\PaymentServiceGraphQl\Plugin\GetFrontendUrl class                                                                          
                                                                                                                                        

In GetParameterClassTrait.php line 34:
                                                                             
  Class "Magento\Support\Model\Report\Group\Modules\Modules" does not exist
```