### PR TITLE
Handle PaytrailConfig return when payment method disabled

### DIFF
--- a/Model/Resolver/PaytrailConfig.php
+++ b/Model/Resolver/PaytrailConfig.php
@@ -34,7 +34,7 @@ class PaytrailConfig implements ResolverInterface
 
         $config = $this->configProvider->getConfig();
 
-        $methodGroups = $config['payment']['paytrail']['method_groups'];
+        $methodGroups = $config['payment']['paytrail']['method_groups'] ?? [];
 
         return [
             'groups' => $methodGroups


### PR DESCRIPTION
If the Paytrail payment method was queried when the payment method was not enabled from the magento admin. The Resolver would end up failing due to an undefined array key "payment" error.

Added null check for the payment method group assignment so it doesn't fail on undefined array key errors.

```
GraphQL (10:3)
 9:         
10:   paytrailConfigData(cart_id: $cartId) {
      ^
11:     groups {
 {"exception":"[object] (GraphQL\\Error\\Error(code: 0): Warning: Undefined array key \"payment\" in /var/www/html/app/code/Paytrail/PaymentServiceGraphQl/Model/Resolver/PaytrailConfig.php on line 37 at /var/www/html/vendor/webonyx/graphql-php/src/Error/Error.php:170)
[previous exception] [object] (Exception(code: 0): Warning: Undefined array key \"payment\" in /var/www/html/app/code/Paytrail/PaymentServiceGraphQl/Model/Resolver/PaytrailConfig.php on line 37 at /var/www/html/vendor/magento/framework/App/ErrorHandler.php:62)","unique_id":"f66c4dbc"} []
```